### PR TITLE
Feat: Open Graph 태그 작동 오류 수정

### DIFF
--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -19,11 +19,18 @@ const SEO = ({ title, description, image }: Props) => {
         {title} | {siteName}
       </title>
       <meta name="description" content={description} />
+      {/* Open Graph */}
       <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
       <meta property="og:url" content={`${siteUrl}${pathname}`} />
-      <meta property="og:image" content={image} />
       <meta property="og:site_name" content={siteName} />
+      {description && <meta property="og:description" content={description} />}
+      {image && <meta property="og:image" content={image} />}
+
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title} />
+      {description && <meta name="twitter:description" content={title} />}
+      {image && <meta name="twitter:image" content={image} />}
+
       <meta
         name="google-site-verification"
         content="XuYZDwUE6RHYN-MpEJhfTnegOVDz8jolBYYFBZT1A1I"

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import useSiteMetaData from '../../hooks/useSiteMetaData';
 import { Helmet } from 'react-helmet';
+import { useLocation } from '@reach/router';
 
 type Props = {
   title: string;
@@ -10,6 +11,7 @@ type Props = {
 
 const SEO = ({ title, description, image }: Props) => {
   const { title: siteName, siteUrl } = useSiteMetaData();
+  const { pathname } = useLocation();
 
   return (
     <Helmet htmlAttributes={{ lang: 'ko' }}>
@@ -19,7 +21,7 @@ const SEO = ({ title, description, image }: Props) => {
       <meta name="description" content={description} />
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
-      <meta property="og:url" content={siteUrl} />
+      <meta property="og:url" content={`${siteUrl}${pathname}`} />
       <meta property="og:image" content={image} />
       <meta property="og:site_name" content={siteName} />
       <meta


### PR DESCRIPTION
관련 이슈
- #64 

`facebook`, `kakao` 등 Open Graph 태그가 정상 작동하지 않는 오류 수정

<img width="373" alt="스크린샷 2021-11-09 오전 9 21 30" src="https://user-images.githubusercontent.com/49791336/140838924-e091539f-81ed-4039-ad87-ab3c1073c054.png">
